### PR TITLE
Use credential helper to provide credentials for pushing to `android-news-app`

### DIFF
--- a/scripts/create_bridget_pr.sh
+++ b/scripts/create_bridget_pr.sh
@@ -17,6 +17,8 @@ mv -f ../bridget-android/library/build/libs/library.jar bridget/src/main/libs/br
 # Commit & push new bridget jar
 git config --global user.name "GuardianAndroid"
 git config --global user.email "guardian.android@gmail.com"
+git config --global credential.helper "/bin/bash ./scripts/credential-helper.sh"
+
 git commit bridget/src/main/libs/bridget.jar -m "Update to bridget version $CURRENT_VERSION"
 git push origin $BRANCH_NAME
 

--- a/scripts/credential-helper.sh
+++ b/scripts/credential-helper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo username=GuardianAndroid
+echo password=$GUARDIANANDROID_PAT


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

1. Adds a `credential-helper.sh` to provide credentials for git remote actions
2. Updates `create-bridget-pr.sh` to use the credential helper

Inspired from the [core Bridget repo](https://github.com/guardian/bridget/blob/main/.github/actions/generate-native-package/credential-helper.sh).

