### PR TITLE
Create Android PR when a release is created

### DIFF
--- a/.github/workflows/bridget_update.yml
+++ b/.github/workflows/bridget_update.yml
@@ -1,13 +1,13 @@
 name: Create PR in android-news-app when bridget is updated
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
   build:
+    if: "!github.event.release.prerelease"
     name: Build and copy bridget.jar
     runs-on: 4core-ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
Previously, the workflow ran whenever a tag is created in the repository. We might create tags for all sorts of reasons, not necessarily because we want to create a release and therefore raise a PR in the Android repo.

This change runs the workflow to create a PR in the Android repo only when we've created a Release in `bridget-android`. It does not run if a prerelease was created.

