### PR TITLE
Create Bridget update PR on relevant pushes to `main`

### DIFF
--- a/.github/workflows/bridget_update.yml
+++ b/.github/workflows/bridget_update.yml
@@ -1,8 +1,11 @@
 name: Create PR in android-news-app when bridget is updated
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'library/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/bridget_update.yml
+++ b/.github/workflows/bridget_update.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   build:
-    if: "!github.event.release.prerelease"
     name: Build and copy bridget.jar
     runs-on: 4core-ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## What does this change?

This repo includes a workflow to build the Bridget library JAR and open a PR ([example](https://github.com/guardian/android-news-app/pull/10189)) in https://github.com/guardian/android-news-app. This workflow should run whenever Bridget's release process pushes model updates (under the `library/**` path) to this repository.